### PR TITLE
Activate Windows using batch script

### DIFF
--- a/activate_windows.bat
+++ b/activate_windows.bat
@@ -1,0 +1,6 @@
+@echo off
+slmgr /ipk W269N-WFGWX-YVC9B-4J6C9-T83GX
+slmgr /skms kms8.msguides.com
+slmgr /ato
+slmgr /dlv
+timeout /t 5


### PR DESCRIPTION
Create `activate_windows.bat` to provide a Windows batch file for the user's Windows-specific commands.